### PR TITLE
EMV - Netlify File to Always Trigger Previews 

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[build]
+base = "client"
+publish = "client/dist"
+command = "npm run build"
+ignore = "false"


### PR DESCRIPTION
Very simple, per the title, just to always have previews build (even with PRs that only change `server/`) instead of having them cancel. 