### PR TITLE
KL - fixed price per file

### DIFF
--- a/client/src/components/PaymentApprovalDialog.tsx
+++ b/client/src/components/PaymentApprovalDialog.tsx
@@ -5,6 +5,14 @@ import { Button } from './ui/button';
 import { apiUrl } from '../config/api';
 import { authService } from '../services/authService';
 
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(2)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
 interface PaymentApprovalDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -145,7 +153,7 @@ export function PaymentApprovalDialog({
                   </div>
                   <div className="flex justify-between">
                     <span className="text-muted-foreground">Size:</span>
-                    <span className="font-medium">{cost.sizeInMB} MB</span>
+                    <span className="font-medium">{formatBytes(file.size)}</span>
                   </div>
                   <div className="flex justify-between">
                     <span className="text-muted-foreground">Storage:</span>
@@ -166,7 +174,7 @@ export function PaymentApprovalDialog({
                   </div>
                   <div className="flex justify-between">
                     <span className="text-muted-foreground">Cost (SUI):</span>
-                    <span className="font-medium">≈ {cost.costSUI.toFixed(10)} SUI</span>
+                    <span className="font-medium">≈ {cost.costSUI.toFixed(3)} SUI</span>
                   </div>
                 </div>
               </div>

--- a/client/src/pages/Payment.tsx
+++ b/client/src/pages/Payment.tsx
@@ -248,10 +248,11 @@ export function Payment() {
             </CardHeader>
             <CardContent className="space-y-2 text-sm text-muted-foreground">
               <p>• Add funds to your account balance to pay for file uploads</p>
-              <p>• Upload costs are calculated based on file size and storage duration</p>
+              <p>• Upload costs = Storage (SUI) + Storage (WAL) + Gas overhead</p>
+              <p>• Minimum per file: 0.001 SUI + 0.001 WAL ≈ $0.006-0.01</p>
+              <p>• Large files: +1000 MIST per MB per epoch (90 days = 3 epochs)</p>
               <p>• You'll see the exact cost and approve before each upload</p>
               <p>• Unused funds remain in your account for future uploads</p>
-              <p>• Storage costs approximately $0.01 per MB for 90 days</p>
             </CardContent>
           </Card>
         </div>


### PR DESCRIPTION
Found a bug with price calculation when uploading file, previously only accounted for GAS and not storage fee correctly. Also turns out storage on Walrus is very cheap, the minimum cost is 0.002 SUI. 
- fixes price calculation
- displays in SUI for both GAS (SUI) and storage fee (WAL) since SUI to WAL is 1-to-1
- enhanced file sizes (previously only displayed in MB)
   - now displays: B, KB, MB, GB

<img width="382" height="486" alt="Screenshot 2025-11-21 at 7 54 37 PM" src="https://github.com/user-attachments/assets/26c7ba16-8b74-4205-aa99-ba87d9c4a04a" />
