### PR TITLE
Refactor balance display

### DIFF
--- a/client/src/components/BatchPaymentApprovalDialog.tsx
+++ b/client/src/components/BatchPaymentApprovalDialog.tsx
@@ -247,23 +247,21 @@ export function BatchPaymentApprovalDialog({
                 </div>
               </div>
 
-              {/* Balance Info */}
-              <div className={`rounded-lg border p-4 ${
-                insufficientFunds
-                  ? 'border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-950'
-                  : 'border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950'
-              }`}>
-                <div className="flex justify-between text-sm">
-                  <span className="text-muted-foreground">Your Balance:</span>
-                  <span className="font-bold">${balance.toFixed(2)}</span>
+              {/* Balance Info - Only show when funds are sufficient */}
+              {!insufficientFunds && (
+                <div className="rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-950">
+                  <div className="flex justify-between text-sm">
+                    <span className="text-muted-foreground">Your Balance:</span>
+                    <span className="font-bold">${balance.toFixed(2)}</span>
+                  </div>
+                  <div className="mt-1 flex justify-between text-sm">
+                    <span className="text-muted-foreground">After Upload:</span>
+                    <span className="font-bold text-green-600 dark:text-green-400">
+                      ${Math.max(0, balance - (cost?.totalCostUSD || 0)).toFixed(2)}
+                    </span>
+                  </div>
                 </div>
-                <div className="mt-1 flex justify-between text-sm">
-                  <span className="text-muted-foreground">After Upload:</span>
-                  <span className={`font-bold ${insufficientFunds ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'}`}>
-                    ${Math.max(0, balance - (cost?.totalCostUSD || 0)).toFixed(2)}
-                  </span>
-                </div>
-              </div>
+              )}
 
               {/* Insufficient Funds Warning */}
               {insufficientFunds && (
@@ -273,7 +271,7 @@ export function BatchPaymentApprovalDialog({
                     <div className="text-sm">
                       <p className="font-semibold">Insufficient Balance</p>
                       <p className="mt-1">
-                        You need ${(cost.totalCostUSD - balance).toFixed(2)} more to complete this batch upload.
+                        Your Balance: ${balance.toFixed(2)}. You need ${(cost.totalCostUSD - balance).toFixed(2)} more to complete this batch upload.
                         Please add funds to your account.
                       </p>
                     </div>

--- a/client/src/components/PaymentApprovalDialog.tsx
+++ b/client/src/components/PaymentApprovalDialog.tsx
@@ -231,23 +231,21 @@ export function PaymentApprovalDialog({
                 </div>
               </div>
 
-              {/* Balance Info */}
-              <div className={`rounded-lg border p-4 ${
-                insufficientFunds
-                  ? 'border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-950'
-                  : 'border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950'
-              }`}>
-                <div className="flex justify-between text-sm">
-                  <span className="text-muted-foreground">Your Balance:</span>
-                  <span className="font-bold">${balance.toFixed(2)}</span>
+              {/* Balance Info - Only show when funds are sufficient */}
+              {!insufficientFunds && (
+                <div className="rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-950">
+                  <div className="flex justify-between text-sm">
+                    <span className="text-muted-foreground">Your Balance:</span>
+                    <span className="font-bold">${balance.toFixed(2)}</span>
+                  </div>
+                  <div className="mt-1 flex justify-between text-sm">
+                    <span className="text-muted-foreground">After Upload:</span>
+                    <span className="font-bold text-green-600 dark:text-green-400">
+                      ${Math.max(0, balance - (cost?.costUSD || 0)).toFixed(2)}
+                    </span>
+                  </div>
                 </div>
-                <div className="mt-1 flex justify-between text-sm">
-                  <span className="text-muted-foreground">After Upload:</span>
-                  <span className={`font-bold ${insufficientFunds ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'}`}>
-                    ${Math.max(0, balance - (cost?.costUSD || 0)).toFixed(2)}
-                  </span>
-                </div>
-              </div>
+              )}
 
               {/* Insufficient Funds Warning */}
               {insufficientFunds && (
@@ -257,7 +255,7 @@ export function PaymentApprovalDialog({
                     <div className="text-sm">
                       <p className="font-semibold">Insufficient Balance</p>
                       <p className="mt-1">
-                        You need ${(cost.costUSD - balance).toFixed(2)} more to complete this upload.
+                        Your Balance: ${balance.toFixed(2)}. You need ${(cost.costUSD - balance).toFixed(2)} more to complete this upload.
                         Please add funds to your account.
                       </p>
                     </div>


### PR DESCRIPTION
Change Payment and Batch Payment Approval dialog to show balance info only when funds are sufficient. Updated insufficient funds warning to include current balance for clarity. Screenshots show new UI for batched uploads, regular uploads (both with sufficient funds and without). Closes #153 

<img width="461" height="758" alt="regular_no_funds" src="https://github.com/user-attachments/assets/53dd7e33-757c-4e0a-bc49-79b0f34f36b4" />
<img width="455" height="754" alt="batch_no_funds" src="https://github.com/user-attachments/assets/009cbdf7-1d68-44ce-a6dc-ba6ae9441e8a" />
<img width="462" height="729" alt="batched" src="https://github.com/user-attachments/assets/dcc803b9-a9d0-4943-87e9-407f695c1315" />
<img width="458" height="724" alt="regular" src="https://github.com/user-attachments/assets/95b381cf-148a-4897-8b6d-fd4a5431de86" />
