### PR TITLE
KL - added redirects for signup from shared files page

### DIFF
--- a/client/src/pages/Join.tsx
+++ b/client/src/pages/Join.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { useNavigate, Link } from "react-router-dom";
+import { useNavigate, Link, useLocation } from "react-router-dom";
 import { Eye, EyeOff, Loader2 } from "lucide-react";
 import { authService } from "../services/authService";
 import { useAuth } from "../auth/AuthContext";
@@ -16,6 +16,7 @@ import SlidesCarousel from "../components/SlidesCarousel";
 
 export const Join: React.FC = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const { setPrivateKey } = useAuth();
 
   const [step, setStep] = useState<number>(1);
@@ -198,7 +199,26 @@ export const Join: React.FC = () => {
       // 5. Store master key in memory for this session
       setPrivateKey(`0x${masterKeyHex}`);
 
-      navigate("/home");
+      const pendingShareId = sessionStorage.getItem("pendingShareId");
+      const pendingShareReturnTo = sessionStorage.getItem(
+        "pendingShareReturnTo",
+      );
+      const returnTo = (location.state as any)?.from || pendingShareReturnTo;
+
+      if (pendingShareId) {
+        sessionStorage.removeItem("pendingShareId");
+      }
+      if (pendingShareReturnTo) {
+        sessionStorage.removeItem("pendingShareReturnTo");
+      }
+
+      if (returnTo) {
+        navigate(returnTo);
+      } else if (pendingShareId) {
+        navigate(`/s/${pendingShareId}`);
+      } else {
+        navigate("/home");
+      }
     } catch (err: any) {
       console.error("[Join] Signup failed:", err);
       setButtonError("Signup failed");

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -298,9 +298,17 @@ export default function Login() {
             <div className="link-center divider">
               <p className="label info-text">
                 Don't have an account?{" "}
-                <a href="/join" className="small-link">
+                <Link
+                  to="/join"
+                  state={
+                    (location.state as any)?.from
+                      ? { from: (location.state as any)?.from }
+                      : undefined
+                  }
+                  className="small-link"
+                >
                   Join now
-                </a>
+                </Link>
               </p>
             </div>
           </div>

--- a/client/src/pages/SharePage.tsx
+++ b/client/src/pages/SharePage.tsx
@@ -240,6 +240,10 @@ export default function SharePage() {
     // Store the share info in sessionStorage so we can use it after redirect
     sessionStorage.setItem("pendingShareId", shareId || "");
     sessionStorage.setItem("pendingShareSave", shareId || "");
+    sessionStorage.setItem(
+      "pendingShareReturnTo",
+      window.location.pathname + window.location.hash,
+    );
     navigate("/login", {
       state: { from: window.location.pathname + window.location.hash },
     });
@@ -515,7 +519,7 @@ export default function SharePage() {
 
                         {saveSuccess && (
                           <div className="text-sm text-emerald-300 opacity-80">
-                            Saved to your files
+                            File added successfully
                           </div>
                         )}
                       </div>


### PR DESCRIPTION
- closes #213 
- clicking login to save to files on shared links, if user signs up for an account, upon completion redirected back to the shared link and that file is added to shared files page
- previously the redirect only occured if user logged in