### PR TITLE
update passowrd checker

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -40,7 +40,8 @@
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
         "tweetnacl": "^1.0.3",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "zxcvbn": "^4.4.2"
       },
       "devDependencies": {
         "@types/bip39": "^2.4.2",
@@ -10985,6 +10986,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/zxcvbn": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/zxcvbn/-/zxcvbn-4.4.2.tgz",
+      "integrity": "sha512-Bq0B+ixT/DMyG8kgX2xWcI5jUvCwqrMxSFam7m0lAf78nf04hv6lNCsyLYdyYTrCVMqNDY/206K7eExYCeSyUQ==",
+      "license": "MIT"
     }
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -54,7 +54,8 @@
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
     "tweetnacl": "^1.0.3",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "zxcvbn": "^4.4.2"
   },
   "eslintConfig": {
     "extends": [

--- a/client/src/lib/passwordStrength.ts
+++ b/client/src/lib/passwordStrength.ts
@@ -1,0 +1,63 @@
+/**
+ * Password strength using zxcvbn (https://github.com/dropbox/zxcvbn).
+ * Replaces per-rule checks (uppercase, number, etc.) with a single "strong" requirement.
+ */
+
+import zxcvbn from "zxcvbn";
+
+/** Minimum score (0-4) considered "strong" — matches server validation. */
+export const MIN_STRONG_SCORE = 3;
+
+export type PasswordStrengthResult = {
+  score: number;
+  isStrong: boolean;
+  label: string;
+  color: string;
+  warning?: string;
+  suggestion?: string;
+};
+
+const LABELS: Record<number, { label: string; color: string }> = {
+  0: { label: "Very weak", color: "status-red" },
+  1: { label: "Weak", color: "status-red" },
+  2: { label: "Fair", color: "status-yellow" },
+  3: { label: "Strong", color: "status-green" },
+  4: { label: "Very strong", color: "status-green" },
+};
+
+/**
+ * Evaluate password strength with zxcvbn.
+ * Pass userInputs (e.g. username, email) so passwords containing them are penalized.
+ */
+export function getPasswordStrength(
+  password: string,
+  userInputs: string[] = [],
+): PasswordStrengthResult {
+  if (!password || password.length < 8) {
+    return {
+      score: 0,
+      isStrong: false,
+      label: "Too short",
+      color: "status-red",
+    };
+  }
+  if (password.length > 72) {
+    return {
+      score: 0,
+      isStrong: false,
+      label: "Too long",
+      color: "status-red",
+    };
+  }
+  const result = zxcvbn(password, userInputs);
+  const score = Math.min(result.score, 4);
+  const { label, color } = LABELS[score] ?? LABELS[0];
+  return {
+    score,
+    isStrong: score >= MIN_STRONG_SCORE,
+    label,
+    color,
+    warning: result.feedback?.warning || undefined,
+    suggestion: result.feedback?.suggestions?.[0],
+  };
+}

--- a/server/app/api/auth/change-password/route.ts
+++ b/server/app/api/auth/change-password/route.ts
@@ -5,6 +5,7 @@ import {
   verifyPassword,
   hashAuthKey,
   verifyAuthKey,
+  validatePassword,
 } from "../../_utils/password";
 import { withCORS } from "../../_utils/cors";
 
@@ -30,9 +31,13 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    if (newPassword.length < 8) {
+    const passwordValidation = validatePassword(newPassword);
+    if (!passwordValidation.valid) {
       return NextResponse.json(
-        { error: "New password must be at least 8 characters" },
+        {
+          error: "Password is not strong enough",
+          details: passwordValidation.errors,
+        },
         { status: 400, headers: withCORS(request) },
       );
     }

--- a/server/app/api/auth/reset-password-recovery/route.ts
+++ b/server/app/api/auth/reset-password-recovery/route.ts
@@ -24,7 +24,7 @@ export async function POST(request: NextRequest) {
     if (!passwordValidation.valid) {
       return NextResponse.json(
         {
-          error: "Password does not meet requirements",
+          error: "Password is not strong enough",
           details: passwordValidation.errors,
         },
         { status: 400, headers: withCORS(request) },

--- a/server/app/api/auth/signup/route.ts
+++ b/server/app/api/auth/signup/route.ts
@@ -100,11 +100,11 @@ export async function POST(request: NextRequest) {
     }
     // OLD FLOW: Backward compatibility (deprecated)
     else if (password) {
-      const passwordValidation = validatePassword(password);
+      const passwordValidation = validatePassword(password, [normalizedUsername]);
       if (!passwordValidation.valid) {
         return NextResponse.json(
           {
-            error: "Password does not meet requirements",
+            error: "Password is not strong enough",
             details: passwordValidation.errors,
           },
           { status: 400, headers: withCORS(request) },

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -21,7 +21,8 @@
                 "pg": "^8.11.3",
                 "react": "^18.3.0",
                 "react-dom": "^18.3.0",
-                "stripe": "^20.1.2"
+                "stripe": "^20.1.2",
+                "zxcvbn": "^4.4.2"
             },
             "devDependencies": {
                 "@types/bcryptjs": "^2.4.6",
@@ -4153,6 +4154,12 @@
             "engines": {
                 "node": ">=0.4"
             }
+        },
+        "node_modules/zxcvbn": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/zxcvbn/-/zxcvbn-4.4.2.tgz",
+            "integrity": "sha512-Bq0B+ixT/DMyG8kgX2xWcI5jUvCwqrMxSFam7m0lAf78nf04hv6lNCsyLYdyYTrCVMqNDY/206K7eExYCeSyUQ==",
+            "license": "MIT"
         }
     }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -27,7 +27,8 @@
         "pg": "^8.11.3",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
-        "stripe": "^20.1.2"
+        "stripe": "^20.1.2",
+        "zxcvbn": "^4.4.2"
     },
     "devDependencies": {
         "@types/bcryptjs": "^2.4.6",


### PR DESCRIPTION
# PR: Password strength with zxcvbn
- closes #254 
## What it does

Replaces the old password rules (e.g. “must have 1 uppercase, 1 number, 1 special character”) with a single requirement: **the password must be “strong”** as measured by [zxcvbn](https://github.com/dropbox/zxcvbn).

- **Sign-up** (Join), **change password** (Profile), and **reset password** (Forgot Password) all use the same strength check.
- The UI shows a single strength label (Very weak → Very strong) and, when weak, optional warning + suggestion from zxcvbn instead of a checklist.

## How it works

- **zxcvbn** scores passwords 0–4 using pattern matching and guessability (common words, sequences, keyboard patterns, etc.). We treat **score ≥ 3** as “strong” and allow the password.
- **Backend:** `server/app/api/_utils/password.ts` uses zxcvbn in `validatePassword()`. Signup and reset/change-password routes call it and return a clear error (“Password is not strong enough”) plus zxcvbn feedback when invalid.
- **Frontend:** `client/src/lib/passwordStrength.ts` exposes `getPasswordStrength(password, userInputs?)`. Join, ForgotPassword, and Profile use it for live feedback; optional `userInputs` (e.g. username) penalizes passwords that contain them.
- Strength, warning, and suggestion are shown on separate lines under the password field to avoid awkward wrapping.

No per-rule checks; one requirement (strong) on both client and server, aligned with the recommended approach from the email feedback.

<img width="672" height="536" alt="Screenshot 2026-02-15 at 3 02 49 PM" src="https://github.com/user-attachments/assets/4f3bf3ea-8254-444a-871c-f1875c96f902" />
<img width="421" height="298" alt="Screenshot 2026-02-15 at 3 01 31 PM" src="https://github.com/user-attachments/assets/2049dfc3-3b3b-4f62-b6cc-a3dcb0aa4233" />
<img width="409" height="117" alt="Screenshot 2026-02-15 at 3 01 05 PM" src="https://github.com/user-attachments/assets/f85fcae4-17a9-43e3-9c2e-02e5fd5612de" />
<img width="433" height="124" alt="Screenshot 2026-02-15 at 3 00 55 PM" src="https://github.com/user-attachments/assets/7c71d4e3-2694-40bb-919a-b7a1bd769c61" />
<img width="411" height="163" alt="Screenshot 2026-02-15 at 3 00 17 PM" src="https://github.com/user-attachments/assets/773810f2-fd35-4dcf-843f-6193bad189cc" />
<img width="416" height="183" alt="Screenshot 2026-02-15 at 2 59 48 PM" src="https://github.com/user-attachments/assets/f75d3750-9794-4480-a817-002b47852461" />
<img width="415" height="171" alt="Screenshot 2026-02-15 at 2 59 37 PM" src="https://github.com/user-attachments/assets/cb60d4e2-232f-4b2b-9b9f-2753d7c2fdbf" />
<img width="418" height="315" alt="Screenshot 2026-02-15 at 2 59 29 PM" src="https://github.com/user-attachments/assets/11b4fd48-6442-4565-a2b4-d0e86649e838" />
